### PR TITLE
corrijo error antes el personaje no seteaba su antigua celda en null …

### DIFF
--- a/src/main/java/org/thegoats/rolgar2/game/GameCharacter.java
+++ b/src/main/java/org/thegoats/rolgar2/game/GameCharacter.java
@@ -112,11 +112,13 @@ public final class GameCharacter {
         var newCell = world.getCell(position);
         Assert.isTrue(newCell.characterCanMove(), "El personaje no puede moverse a la posicion: " + position);
 
-        var previousCell = world.getCell(newCell.getPosition());
-
-        previousCell.setCharacter(null);
-        newCell.setCharacter(this);
-        setWorldCell(newCell);
+        world.getCell(this.worldCell.getPosition()).setCharacter(null);
+        try{
+            newCell.setCharacter(this);
+            setWorldCell(newCell);
+        } catch (IllegalStateException e){
+            System.out.println(e.getMessage());
+        }
     }
 
     // TODO: TELEPORT CHARACTER URGENTE !!!!!!!!!!

--- a/src/main/java/org/thegoats/rolgar2/world/WorldCell.java
+++ b/src/main/java/org/thegoats/rolgar2/world/WorldCell.java
@@ -135,10 +135,10 @@ public class WorldCell {
         if (wall == null) {
             this.wall = null;
         } else {
-            if (character != null) {
+            if (hasCharacter()) {
                 throw new IllegalStateException("La celda contiene un personaje actualmente");
             }
-            if (card != null) {
+            if (hasCard()) {
                 throw new IllegalStateException("La celda contiene una carta actualmente");
             }
 
@@ -153,11 +153,11 @@ public class WorldCell {
         if (character == null) {
             this.character = null;
         } else {
-            if (wall != null) {
+            if (hasWall()) {
                 throw new IllegalStateException("La celda contiene un muro actualmente");
             }
-            if (card != null) {
-                throw new IllegalStateException("La celda contiene una carta actualmente");
+            if(hasCharacter()){
+                throw new IllegalStateException("La celda contiene un personaje actualmente");
             }
 
             this.character = character;
@@ -171,10 +171,10 @@ public class WorldCell {
         if (card == null) {
             this.card = null;
         } else {
-            if (wall != null) {
+            if (hasWall()) {
                 throw new IllegalStateException("La celda contiene un muro actualmente");
             }
-            if (character != null) {
+            if (hasCharacter()) {
                 throw new IllegalStateException("La celda contiene un personaje actualmente");
             }
             this.card = card;
@@ -192,7 +192,7 @@ public class WorldCell {
      * @return true si contiene algun cha
      */
     public boolean isOccupied() {
-        return !hasWall() || !hasCharacter();
+        return hasWall() || hasCharacter();
     }
 
     public boolean isFree(){


### PR DESCRIPTION
bugfix: antes la celda previa del jugador no se marcaba como null.
Atrapo las excepciones de setCharacter en gameCharacter para mostrarlas en la consola sin cortar la ejecucion.